### PR TITLE
Also print perfdata if we only have one

### DIFF
--- a/cmd/query.go
+++ b/cmd/query.go
@@ -147,7 +147,7 @@ func queryFluxV2(fluxQuery, url, org, token string, c *http.Client) {
 	}
 
 	// If we got perfdata we print the only the last value
-	if len(perfData) > 1 {
+	if len(perfData) >= 1 {
 		check.ExitRaw(rc, "InfluxDB Query Status", "|", perfData[len(perfData)-1].String())
 	}
 


### PR DESCRIPTION
Fix on 181ad1f, which limits printing of perf data to only the last set of data.  However, the guard incorrectly restricts the printing to cases where we have at least two, not at least one.