### PR TITLE
Print perfdata to normal output

### DIFF
--- a/cmd/query.go
+++ b/cmd/query.go
@@ -148,7 +148,7 @@ func queryFluxV2(fluxQuery, url, org, token string, c *http.Client) {
 
 	// If we got perfdata we print the only the last value
 	if len(perfData) >= 1 {
-		check.ExitRaw(rc, "InfluxDB Query Status", "|", perfData[len(perfData)-1].String())
+		check.ExitRaw(rc, "InfluxDB Query Status", perfData[len(perfData)-1].String(), "|", perfData[len(perfData)-1].String())
 	}
 
 	check.ExitRaw(rc, "InfluxDB Query Status")


### PR DESCRIPTION
I really find it helpful if my icinga notifications give me some insight on how outside the expected range a datapoint falls.

 It seems the easiest approach is to just repeat the perdata in the "plain text" part of the output as well, so it gets picked up by my notification scripts as well as the icingaweb default output.

e.g.:
```
% ./etc/shell_wrapped/influx-kueche-fridge-temperature
[OK] - InfluxDB Query Status temperature=6.2;12;15 | temperature=6.2;12;15
```

(This is on top of pull-request #37.)